### PR TITLE
Feat: Add useful functions to the new `stringex` extension module

### DIFF
--- a/src/Lua/Standard/OpenLibsExtensions.cs
+++ b/src/Lua/Standard/OpenLibsExtensions.cs
@@ -131,6 +131,18 @@ public static class OpenLibsExtensions
         state.LoadedModules["table"] = table;
     }
 
+    public static void OpenStringExLibrary(this LuaState state)
+    {
+        var stringex = new LuaTable(0, StringExLibrary.Instance.Functions.Length);
+        foreach (var func in StringExLibrary.Instance.Functions)
+        {
+            stringex[func.Name] = func;
+        }
+
+        state.Environment["stringex"] = stringex;
+        state.LoadedModules["stringex"] = stringex;
+    }
+
     public static void OpenStandardLibraries(this LuaState state)
     {
         state.OpenBasicLibrary();
@@ -142,5 +154,10 @@ public static class OpenLibsExtensions
         state.OpenOperatingSystemLibrary();
         state.OpenStringLibrary();
         state.OpenTableLibrary();
+    }
+
+    public static void OpenExtensionLibraries(this LuaState state)
+    {
+        state.OpenStringExLibrary();
     }
 }

--- a/src/Lua/Standard/StringExLibrary.cs
+++ b/src/Lua/Standard/StringExLibrary.cs
@@ -1,0 +1,93 @@
+using System.Text;
+using Lua.Internal;
+
+namespace Lua.Standard;
+
+public sealed class StringExLibrary
+{
+    public static readonly StringExLibrary Instance = new();
+
+    public StringExLibrary()
+    {
+        Functions = [
+            new("trim", Trim),
+            new("trimStart", TrimStart),
+            new("trimStart", TrimEnd),
+            new("lowerInvariant", LowerInvariant),
+            new("upperInvariant", UpperInvariant),
+            new("contains", Contains),
+            new("startsWith", StartsWith),
+            new("endsWith", EndsWith),
+            new("equalsIgnoreCase", EqualsIgnoreCase),
+        ];
+    }
+
+    public readonly LuaFunction[] Functions;
+
+    public ValueTask<int> Trim(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        buffer.Span[0] = s.Trim();
+        return new(1);
+    }
+
+    public ValueTask<int> TrimStart(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        buffer.Span[0] = s.TrimStart();
+        return new(1);
+    }
+
+    public ValueTask<int> TrimEnd(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        buffer.Span[0] = s.TrimEnd();
+        return new(1);
+    }
+
+    public ValueTask<int> LowerInvariant(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        buffer.Span[0] = s.ToLowerInvariant();
+        return new(1);
+    }
+
+    public ValueTask<int> UpperInvariant(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        buffer.Span[0] = s.ToUpperInvariant();
+        return new(1);
+    }
+    
+    public ValueTask<int> Contains(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        var s2 = context.GetArgument<string>(1);
+        buffer.Span[0] = s.Contains(s2);
+        return new(1);
+    }
+    
+    public ValueTask<int> StartsWith(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        var s2 = context.GetArgument<string>(1);
+        buffer.Span[0] = s.StartsWith(s2);
+        return new(1);
+    }
+    
+    public ValueTask<int> EndsWith(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        var s2 = context.GetArgument<string>(1);
+        buffer.Span[0] = s.EndsWith(s2);
+        return new(1);
+    }
+
+    public ValueTask<int> EqualsIgnoreCase(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        var s2 = context.GetArgument<string>(1);
+        buffer.Span[0] = string.Equals(s, s2, StringComparison.OrdinalIgnoreCase);
+        return new(1);
+    }
+}

--- a/src/Lua/Standard/StringExLibrary.cs
+++ b/src/Lua/Standard/StringExLibrary.cs
@@ -12,7 +12,7 @@ public sealed class StringExLibrary
         Functions = [
             new("trim", Trim),
             new("trimStart", TrimStart),
-            new("trimStart", TrimEnd),
+            new("trimEnd", TrimEnd),
             new("lowerInvariant", LowerInvariant),
             new("upperInvariant", UpperInvariant),
             new("contains", Contains),

--- a/src/Lua/Standard/StringLibrary.cs
+++ b/src/Lua/Standard/StringLibrary.cs
@@ -23,9 +23,12 @@ public sealed class StringLibrary
             new("reverse", Reverse),
             new("sub", Sub),
             new("upper", Upper),
+            new("lowerInvariant", LowerInvariant),
+            new("upperInvariant", UpperInvariant),
             new("contains", Contains),
             new("startsWith", StartsWith),
             new("endsWith", EndsWith),
+            new("equalsIgnoreCase", EqualsIgnoreCase),
         ];
     }
 
@@ -574,6 +577,13 @@ public sealed class StringLibrary
         return new(1);
     }
 
+    public ValueTask<int> LowerInvariant(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        buffer.Span[0] = s.ToLowerInvariant();
+        return new(1);
+    }
+
     public ValueTask<int> Rep(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
     {
         var s = context.GetArgument<string>(0);
@@ -632,6 +642,13 @@ public sealed class StringLibrary
         buffer.Span[0] = s.ToUpper();
         return new(1);
     }
+
+    public ValueTask<int> UpperInvariant(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        buffer.Span[0] = s.ToUpperInvariant();
+        return new(1);
+    }
     
     public ValueTask<int> Contains(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
     {
@@ -654,6 +671,14 @@ public sealed class StringLibrary
         var s = context.GetArgument<string>(0);
         var s2 = context.GetArgument<string>(1);
         buffer.Span[0] = s.EndsWith(s2);
+        return new(1);
+    }
+
+    public ValueTask<int> EqualsIgnoreCase(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        var s2 = context.GetArgument<string>(1);
+        buffer.Span[0] = string.Equals(s, s2, StringComparison.OrdinalIgnoreCase);
         return new(1);
     }
 }

--- a/src/Lua/Standard/StringLibrary.cs
+++ b/src/Lua/Standard/StringLibrary.cs
@@ -23,6 +23,9 @@ public sealed class StringLibrary
             new("reverse", Reverse),
             new("sub", Sub),
             new("upper", Upper),
+            new("contains", Contains),
+            new("startsWith", StartsWith),
+            new("endsWith", EndsWith),
         ];
     }
 
@@ -627,6 +630,30 @@ public sealed class StringLibrary
     {
         var s = context.GetArgument<string>(0);
         buffer.Span[0] = s.ToUpper();
+        return new(1);
+    }
+    
+    public ValueTask<int> Contains(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        var s2 = context.GetArgument<string>(1);
+        buffer.Span[0] = s.Contains(s2);
+        return new(1);
+    }
+    
+    public ValueTask<int> StartsWith(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        var s2 = context.GetArgument<string>(1);
+        buffer.Span[0] = s.StartsWith(s2);
+        return new(1);
+    }
+    
+    public ValueTask<int> EndsWith(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
+    {
+        var s = context.GetArgument<string>(0);
+        var s2 = context.GetArgument<string>(1);
+        buffer.Span[0] = s.EndsWith(s2);
         return new(1);
     }
 }

--- a/src/Lua/Standard/StringLibrary.cs
+++ b/src/Lua/Standard/StringLibrary.cs
@@ -23,12 +23,6 @@ public sealed class StringLibrary
             new("reverse", Reverse),
             new("sub", Sub),
             new("upper", Upper),
-            new("lowerInvariant", LowerInvariant),
-            new("upperInvariant", UpperInvariant),
-            new("contains", Contains),
-            new("startsWith", StartsWith),
-            new("endsWith", EndsWith),
-            new("equalsIgnoreCase", EqualsIgnoreCase),
         ];
     }
 
@@ -577,13 +571,6 @@ public sealed class StringLibrary
         return new(1);
     }
 
-    public ValueTask<int> LowerInvariant(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
-    {
-        var s = context.GetArgument<string>(0);
-        buffer.Span[0] = s.ToLowerInvariant();
-        return new(1);
-    }
-
     public ValueTask<int> Rep(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
     {
         var s = context.GetArgument<string>(0);
@@ -640,45 +627,6 @@ public sealed class StringLibrary
     {
         var s = context.GetArgument<string>(0);
         buffer.Span[0] = s.ToUpper();
-        return new(1);
-    }
-
-    public ValueTask<int> UpperInvariant(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
-    {
-        var s = context.GetArgument<string>(0);
-        buffer.Span[0] = s.ToUpperInvariant();
-        return new(1);
-    }
-    
-    public ValueTask<int> Contains(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
-    {
-        var s = context.GetArgument<string>(0);
-        var s2 = context.GetArgument<string>(1);
-        buffer.Span[0] = s.Contains(s2);
-        return new(1);
-    }
-    
-    public ValueTask<int> StartsWith(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
-    {
-        var s = context.GetArgument<string>(0);
-        var s2 = context.GetArgument<string>(1);
-        buffer.Span[0] = s.StartsWith(s2);
-        return new(1);
-    }
-    
-    public ValueTask<int> EndsWith(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
-    {
-        var s = context.GetArgument<string>(0);
-        var s2 = context.GetArgument<string>(1);
-        buffer.Span[0] = s.EndsWith(s2);
-        return new(1);
-    }
-
-    public ValueTask<int> EqualsIgnoreCase(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
-    {
-        var s = context.GetArgument<string>(0);
-        var s2 = context.GetArgument<string>(1);
-        buffer.Span[0] = string.Equals(s, s2, StringComparison.OrdinalIgnoreCase);
         return new(1);
     }
 }


### PR DESCRIPTION
Add some really useful C# string methods in the `stringex` module
`contains`, `startsWith` , `endsWith` , `lowerInvariant`, `upperInvariant`, `equalsIgnoreCase`

Maybe adding a new extension module is a good idea without breaking compatibility with standard lua ?