### PR TITLE
Fix: backslash with real newline in short literal doesn't work

### DIFF
--- a/src/Lua/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Lua/CodeAnalysis/Syntax/Lexer.cs
@@ -311,7 +311,6 @@ public ref struct Lexer
             var quote = c1;
             var stringStartOffset = offset;
             var isTerminated = false;
-            var escape = false;
 
             while (span.Length > offset)
             {
@@ -319,33 +318,26 @@ public ref struct Lexer
 
                 if (c is '\n' or '\r')
                 {
-                    if (escape)
-                    {
-                        escape = false;
-                        Advance(1);
-                        continue;
-                    }
-
                     break;
                 }
 
                 if (c is '\\')
                 {
                     Advance(1);
-                    escape = true;
+
                     if (span.Length <= offset) break;
+                    if (span[offset] == '\r')
+                    {
+                        if (span.Length<=offset +1) continue;
+                        if (span[offset+1] == '\n')Advance(1);
+                    }
                 }
                 else if (c == quote)
                 {
                     isTerminated = true;
                     break;
                 }
-                else
-                {
-                    escape = false;
-                }
 
-                
                 Advance(1);
             }
 
@@ -544,8 +536,8 @@ public ref struct Lexer
     static bool IsIdentifier(char c)
     {
         return c == '_' ||
-            ('A' <= c && c <= 'Z') ||
-            ('a' <= c && c <= 'z') ||
-            StringHelper.IsNumber(c);
+               ('A' <= c && c <= 'Z') ||
+               ('a' <= c && c <= 'z') ||
+               StringHelper.IsNumber(c);
     }
 }

--- a/src/Lua/CodeAnalysis/Syntax/Lexer.cs
+++ b/src/Lua/CodeAnalysis/Syntax/Lexer.cs
@@ -311,6 +311,7 @@ public ref struct Lexer
             var quote = c1;
             var stringStartOffset = offset;
             var isTerminated = false;
+            var escape = false;
 
             while (span.Length > offset)
             {
@@ -318,12 +319,20 @@ public ref struct Lexer
 
                 if (c is '\n' or '\r')
                 {
+                    if (escape)
+                    {
+                        escape = false;
+                        Advance(1);
+                        continue;
+                    }
+
                     break;
                 }
 
                 if (c is '\\')
                 {
                     Advance(1);
+                    escape = true;
                     if (span.Length <= offset) break;
                 }
                 else if (c == quote)
@@ -331,7 +340,12 @@ public ref struct Lexer
                     isTerminated = true;
                     break;
                 }
+                else
+                {
+                    escape = false;
+                }
 
+                
                 Advance(1);
             }
 

--- a/src/Lua/Internal/StringHelper.cs
+++ b/src/Lua/Internal/StringHelper.cs
@@ -37,7 +37,12 @@ internal static class StringHelper
                         builder.Append('\n');
                         break;
                     case '\r':
-                        builder.Append('\r');
+                        builder.Append('\n');
+                        // check CRLF
+                        if (i + 1 < literal.Length && literal[i + 1] is '\n')
+                        {
+                            i++;
+                        }
                         break;
                     case 'a':
                         builder.Append('\a');

--- a/src/Lua/Internal/StringHelper.cs
+++ b/src/Lua/Internal/StringHelper.cs
@@ -38,11 +38,6 @@ internal static class StringHelper
                         break;
                     case '\r':
                         builder.Append('\r');
-                        // check CRLF
-                        if (i + 1 < literal.Length && literal[i + 1] is '\n')
-                        {
-                            i++;
-                        }
                         break;
                     case 'a':
                         builder.Append('\a');
@@ -306,6 +301,7 @@ internal static class StringHelper
                             builder.Append(c);
                             break;
                     }
+
                     isEscapeSequence = false;
                 }
             }
@@ -358,7 +354,7 @@ internal static class StringHelper
     public static bool IsDigit(char c)
     {
         return IsNumber(c) ||
-            ('a' <= c && c <= 'f') ||
-            ('A' <= c && c <= 'F');
+               ('a' <= c && c <= 'f') ||
+               ('A' <= c && c <= 'F');
     }
 }

--- a/tests/Lua.Tests/ParserTests.cs
+++ b/tests/Lua.Tests/ParserTests.cs
@@ -25,5 +25,24 @@ end";
             Assert.That(actual, Is.TypeOf<IfStatementNode>());
             Assert.That(actual.ToString(), Is.EqualTo(expected.ToString()));
         }
+        
+        [Test]
+        public void Test_MultiLine_ShortString()
+        {
+            var source = 
+"""
+print "Hello,\
+World!"
+""";
+            var actual = LuaSyntaxTree.Parse(source).Nodes[0]; 
+             Assert.That(actual, Is.TypeOf<CallFunctionStatementNode>());
+             var literal =((StringLiteralNode)((CallFunctionStatementNode)actual).Expression.ArgumentNodes[0]).Text.ToString();
+             Assert.That(literal,  Is.EqualTo(
+                 """
+                 Hello,\
+                 World!
+                 """
+                 ));
+        }
     }
 }

--- a/tests/Lua.Tests/ParserTests.cs
+++ b/tests/Lua.Tests/ParserTests.cs
@@ -25,24 +25,5 @@ end";
             Assert.That(actual, Is.TypeOf<IfStatementNode>());
             Assert.That(actual.ToString(), Is.EqualTo(expected.ToString()));
         }
-        
-        [Test]
-        public void Test_MultiLine_ShortString()
-        {
-            var source = 
-"""
-print "Hello,\
-World!"
-""";
-            var actual = LuaSyntaxTree.Parse(source).Nodes[0]; 
-             Assert.That(actual, Is.TypeOf<CallFunctionStatementNode>());
-             var literal =((StringLiteralNode)((CallFunctionStatementNode)actual).Expression.ArgumentNodes[0]).Text.ToString();
-             Assert.That(literal,  Is.EqualTo(
-                 """
-                 Hello,\
-                 World!
-                 """
-                 ));
-        }
     }
 }

--- a/tests/Lua.Tests/StringTests.cs
+++ b/tests/Lua.Tests/StringTests.cs
@@ -1,0 +1,17 @@
+using Lua.CodeAnalysis.Syntax;
+using Lua.CodeAnalysis.Syntax.Nodes;
+
+namespace Lua.Tests;
+
+public class StringTests
+{
+    [TestCase("\r")]
+    [TestCase("\n")]
+    [TestCase("\r\n")]
+    public async Task Test_ShortString_RealNewLine(string newLine)
+    {
+        var result = await LuaState.Create().DoStringAsync($"return \"\\{newLine}\"");
+        Assert.That(result, Has.Length.EqualTo(1));
+        Assert.That(result[0], Is.EqualTo(new LuaValue("\n")));
+    }
+}


### PR DESCRIPTION
```lua
print ("Hello, \
  World!")
```
output
```
Hello, 
  World!
```