### PR TITLE
Hotfix making string.format use invariant culture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/

--- a/src/Lua/LuaFunction.cs
+++ b/src/Lua/LuaFunction.cs
@@ -5,7 +5,7 @@ namespace Lua;
 
 public class LuaFunction(string name, Func<LuaFunctionExecutionContext, Memory<LuaValue>, CancellationToken, ValueTask<int>> func)
 {
-    public string Name { get; } = name;
+    public string Name { get; set; } = name;
     internal Func<LuaFunctionExecutionContext, Memory<LuaValue>, CancellationToken, ValueTask<int>> Func { get; } = func;
 
     public LuaFunction(Func<LuaFunctionExecutionContext, Memory<LuaValue>, CancellationToken, ValueTask<int>> func) : this("anonymous", func)

--- a/src/Lua/Runtime/Tracebacks.cs
+++ b/src/Lua/Runtime/Tracebacks.cs
@@ -24,7 +24,8 @@ public class Traceback
                 if (lastFunc is Closure closure)
                 {
                     var p = closure.Proto;
-                    return p.SourcePositions[frame.CallerInstructionIndex];
+                    if (frame.CallerInstructionIndex < p.SourcePositions.Length)
+                        return p.SourcePositions[frame.CallerInstructionIndex];
                 }
             }
 

--- a/src/Lua/Standard/StringLibrary.cs
+++ b/src/Lua/Standard/StringLibrary.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Lua.Internal;
+using System.Globalization;
 
 namespace Lua.Standard;
 
@@ -148,6 +149,9 @@ public sealed class StringLibrary
 
     public async ValueTask<int> Format(LuaFunctionExecutionContext context, Memory<LuaValue> buffer, CancellationToken cancellationToken)
     {
+        var currentCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+
         var format = context.GetArgument<string>(0);
 
         // TODO: pooling StringBuilder
@@ -419,6 +423,9 @@ public sealed class StringLibrary
 
 
         buffer.Span[0] = builder.ToString();
+
+        CultureInfo.CurrentCulture = currentCulture;
+
         return 1;
     }
 

--- a/tests/Lua.Tests/tests-lua/strings.lua
+++ b/tests/Lua.Tests/tests-lua/strings.lua
@@ -133,6 +133,7 @@ assert(string.format("%c",34)..string.format("%c",48)..string.format("%c",90)..s
        string.format("%c%c%c%c", 34, 48, 90, 100))
 assert(string.format("%s\0 is not \0%s", 'not be', 'be') == 'not be\0 is not \0be')
 assert(string.format("%%%d %010d", 10, 23) == "%10 0000000023")
+print("10.3 as string is: " .. string.format("%f", 10.3) .. " and as number: " .. tostring(tonumber(string.format("%f", 10.3))))
 assert(tonumber(string.format("%f", 10.3)) == 10.3)
 x = string.format('"%-50s"', 'a')
 assert(#x == 52)
@@ -280,5 +281,3 @@ assert(os.setlocale(nil, "numeric") == 'C')
 end
 
 print('OK')
-
-


### PR DESCRIPTION
Resolves this issue: https://github.com/nuskey8/Lua-CSharp/issues/116

Straightforward but not ideal solution by switching culture at the start and end of the method. This could be an issue if there's an exception thrown in between, leaving the culture of that thread invariant.
