### PR TITLE
Fix Hex-Float Conversions

### DIFF
--- a/src/Lua/Internal/HexConverter.cs
+++ b/src/Lua/Internal/HexConverter.cs
@@ -86,25 +86,20 @@ public static class HexConverter
 
     static int ToInt(char c)
     {
-        return c switch
+        unchecked
         {
-            '0' => 0,
-            '1' => 1,
-            '2' => 2,
-            '3' => 3,
-            '4' => 4,
-            '5' => 5,
-            '6' => 6,
-            '7' => 7,
-            '8' => 8,
-            '9' => 9,
-            'A' or 'a' => 10,
-            'B' or 'b' => 11,
-            'C' or 'd' => 12,
-            'D' or 'e' => 13,
-            'E' or 'e' => 14,
-            'F' or 'f' => 15,
-            _ => 0
-        };
+            switch (c)
+            {
+                case < '0':
+                    return 0;
+                case <= '9':
+                    return (c - '0');
+                case >= 'A' and <= 'F':
+                    return (c - 'A' + 10);
+                case >= 'a' and <= 'f':
+                    return (c - 'a' + 10);
+            }
+        }
+        return 0;
     }
 }

--- a/tests/Lua.Tests/HexConverterTests.cs
+++ b/tests/Lua.Tests/HexConverterTests.cs
@@ -7,8 +7,12 @@ public class HexConverterTests
     [TestCase("0x10", 16)]
     [TestCase("0x0p12", 0)]
     [TestCase("-0x1.0p-1", -0.5)]
+    [TestCase("0x0.1e", 0.1171875)]
+    [TestCase("0xA23p-4", 162.1875)]
+    [TestCase("0X1.921FB54442D18P+1", 3.1415926535898)]
+    [TestCase("0X1.bcde19p+1", 3.475527882576)]
     public void Test_ToDouble(string text, double expected)
     {
-        Assert.That(HexConverter.ToDouble(text), Is.EqualTo(expected));
+        Assert.That(Math.Abs(HexConverter.ToDouble(text) - expected), Is.LessThanOrEqualTo(0.00001d));
     }
 }


### PR DESCRIPTION
There was an issue with the conversion of hex floats when the float strings were in lowercase. 
Test cases have been added.