### PR TITLE
Improved cancellation process and avoidance of infinite loops

### DIFF
--- a/src/Lua/Exceptions.cs
+++ b/src/Lua/Exceptions.cs
@@ -274,7 +274,7 @@ public sealed class LuaCancelledException : OperationCanceledException, ILuaTrac
 
     internal LuaThread? Thread { get; private set; }
 
-    internal LuaCancelledException(LuaThread thread, CancellationToken cancellationToken, Exception? innerException = null) : base("operation canceled in Lua", innerException, cancellationToken)
+    internal LuaCancelledException(LuaThread thread, CancellationToken cancellationToken, Exception? innerException = null) : base("The operation was cancelled during execution on Lua.", innerException, cancellationToken)
     {
         thread.CurrentException?.BuildOrGet();
         thread.ExceptionTrace.Clear();

--- a/src/Lua/LuaCoroutine.cs
+++ b/src/Lua/LuaCoroutine.cs
@@ -186,9 +186,9 @@ public sealed class LuaCoroutine : LuaThread, IValueTaskSource<LuaCoroutine.Yiel
             {
                 if (IsProtectedMode)
                 {
-                    if (ex is LuaRuntimeException luaRuntimeException)
+                    if (ex is ILuaTracebackBuildable tracebackBuildable)
                     {
-                        traceback = luaRuntimeException.Build();
+                        traceback = tracebackBuildable.BuildOrGet();
                     }
 
                     Volatile.Write(ref status, (byte)LuaThreadStatus.Dead);

--- a/src/Lua/LuaThread.cs
+++ b/src/Lua/LuaThread.cs
@@ -70,8 +70,11 @@ public abstract class LuaThread
     internal int LastVersion;
     internal int CurrentVersion;
 
-    internal LuaRuntimeException? CurrentException;
+    internal ILuaTracebackBuildable? CurrentException;
     internal readonly ReversedStack<CallStackFrame> ExceptionTrace = new();
+    
+    // internal bool CancelRequested;
+    // internal CancellationToken CancellationToken;
 
     public bool IsRunning => CallStackFrameCount != 0;
     internal LuaFunction? Hook { get; set; }
@@ -131,7 +134,7 @@ public abstract class LuaThread
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal LuaThreadAccess PushCallStackFrame(in CallStackFrame frame)
     {
-        CurrentException?.Build();
+        CurrentException?.BuildOrGet();
         CurrentException = null;
         ref var callStack = ref CoreData!.CallStack;
         callStack.Push(frame);

--- a/src/Lua/LuaThreadExtensions.cs
+++ b/src/Lua/LuaThreadExtensions.cs
@@ -13,4 +13,19 @@ public static class LuaThreadExtensions
     {
         return new(LuaCoroutine.Create(thread, function, isProtectedMode));
     }
+
+    internal static void ThrowIfCancellationRequested(this LuaThread thread, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            Throw(thread, cancellationToken);
+        }
+
+        return;
+
+        static void Throw(LuaThread thread, CancellationToken cancellationToken)
+        {
+            throw new LuaCancelledException(thread, cancellationToken);
+        }
+    }
 }

--- a/src/Lua/Runtime/LuaStack.cs
+++ b/src/Lua/Runtime/LuaStack.cs
@@ -32,7 +32,7 @@ public sealed class LuaStack(int initialSize = 256)
 
             if (1000000 < size)
             {
-                throw new LuaException("Lua Stack overflow");
+                throw new ("Lua Stack overflow");
             }
 
             Array.Resize(ref array, size);

--- a/src/Lua/Runtime/LuaThreadAccess.cs
+++ b/src/Lua/Runtime/LuaThreadAccess.cs
@@ -53,6 +53,7 @@ public readonly struct LuaThreadAccess
             throw new ArgumentNullException(nameof(function));
         }
 
+        Thread.ThrowIfCancellationRequested(cancellationToken);
         var thread = Thread;
         var varArgumentCount = function.GetVariableArgumentCount(argumentCount);
         if (varArgumentCount != 0)
@@ -78,7 +79,7 @@ public readonly struct LuaThreadAccess
 
         var access = thread.PushCallStackFrame(frame);
         LuaFunctionExecutionContext context = new() { Access = access, ArgumentCount = argumentCount, ReturnFrameBase = returnBase, };
-
+        var callStackTop = thread.CallStackFrameCount;
         try
         {
             if (this.Thread.CallOrReturnHookMask.Value != 0 && !this.Thread.IsInHook)
@@ -90,7 +91,7 @@ public readonly struct LuaThreadAccess
         }
         finally
         {
-            this.Thread.PopCallStackFrame();
+            this.Thread.PopCallStackFrameUntil(callStackTop-1);
         }
     }
 

--- a/src/Lua/Runtime/LuaVirtualMachine.Debug.cs
+++ b/src/Lua/Runtime/LuaVirtualMachine.Debug.cs
@@ -47,7 +47,7 @@ public static partial class LuaVirtualMachine
                 countHookIsDone = true;
             }
 
-
+            context.ThrowIfCancellationRequested();
             if (context.Thread.IsLineHookEnabled)
             {
                 var sourcePositions = prototype.LineInfo;
@@ -126,6 +126,7 @@ public static partial class LuaVirtualMachine
                 context.Thread.PopCallStackFrameWithStackPop();
             }
         }
+        context.Thread.ThrowIfCancellationRequested(cancellationToken);
 
         {
             var frame = context.Thread.GetCurrentFrame();
@@ -135,7 +136,7 @@ public static partial class LuaVirtualMachine
             {
                 return r;
             }
-
+            context.Thread.ThrowIfCancellationRequested(cancellationToken);
             var top = stack.Count;
             stack.Push("return");
             stack.Push(LuaValue.Nil);

--- a/tests/Lua.Tests/CancellationTest.cs
+++ b/tests/Lua.Tests/CancellationTest.cs
@@ -1,0 +1,180 @@
+﻿using Lua.Standard;
+
+namespace Lua.Tests;
+
+public class CancellationTest
+{
+    LuaState state = default!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        state = LuaState.Create();
+        state.OpenStandardLibraries();
+
+        state.Environment["assert"] = new LuaFunction("assert_with_wait",
+            async (context, ct) =>
+            {
+                await Task.Delay(1, ct);
+                var arg0 = context.GetArgument(0);
+
+                if (!arg0.ToBoolean())
+                {
+                    var message = "assertion failed!";
+                    if (context.HasArgument(1))
+                    {
+                        message = context.GetArgument<string>(1);
+                    }
+
+                    throw new LuaAssertionException(context.Thread, message);
+                }
+
+                return (context.Return(context.Arguments));
+            });
+        state.Environment["sleep"] = new LuaFunction("sleep",
+            (context, _) =>
+            {
+                Thread.Sleep(context.GetArgument<int>(0));
+
+                return new(context.Return());
+            });
+        state.Environment["wait"] = new LuaFunction("wait",
+            async (context, ct) =>
+            {
+                await Task.Delay(context.GetArgument<int>(0), ct);
+                return context.Return();
+            });
+    }
+
+    [Test]
+    public async Task PCall_WaitTest()
+    {
+        var source = """
+                     local function f(millisec)
+                         wait(millisec)
+                     end                     
+                     pcall(f, 500)
+                     """;
+        var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.CancelAfter(200);
+
+        try
+        {
+            await state.DoStringAsync(source, "@test.lua", cancellationTokenSource.Token);
+            Assert.Fail("Expected TaskCanceledException was not thrown.");
+        }
+        catch (Exception e)
+        {
+            Assert.That(e, Is.TypeOf<LuaCancelledException>());
+            var luaCancelledException = (LuaCancelledException)e;
+            Assert.That(luaCancelledException.InnerException, Is.TypeOf<TaskCanceledException>());
+            var luaStackTrace = luaCancelledException.LuaTraceback!.ToString();
+            Console.WriteLine(luaStackTrace);
+            Assert.That(luaStackTrace, Contains.Substring("'wait'"));
+            Assert.That(luaStackTrace, Contains.Substring("'pcall'"));
+        }
+    }
+
+    [Test]
+    public async Task PCall_SleepTest()
+    {
+        var source = """
+                     local function f(millisec)
+                         sleep(millisec)
+                     end                     
+                     pcall(f, 500)
+                     """;
+        var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.CancelAfter(250);
+
+        try
+        {
+            await state.DoStringAsync(source, "@test.lua", cancellationTokenSource.Token);
+            Assert.Fail("Expected TaskCanceledException was not thrown.");
+        }
+        catch (Exception e)
+        {
+            Assert.That(e, Is.TypeOf<LuaCancelledException>());
+            var luaCancelledException = (LuaCancelledException)e;
+            Assert.That(luaCancelledException.InnerException, Is.Null);
+            var luaStackTrace = luaCancelledException.LuaTraceback!.ToString();
+            Console.WriteLine(luaStackTrace);
+            Assert.That(luaStackTrace, Contains.Substring("'sleep'"));
+            Assert.That(luaStackTrace, Contains.Substring("'pcall'"));
+        }
+    }
+
+    [Test]
+    public async Task ForLoopTest()
+    {
+        var source = """
+                     local ret = 0
+                     for i = 1, 1000000000 do
+                         ret = ret + i
+                     end
+                     return ret
+                     """;
+        var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.CancelAfter(100);
+        cancellationTokenSource.Token.Register(() =>
+        {
+            Console.WriteLine("Cancellation requested");
+        });
+        try
+        {
+            var r = await state.DoStringAsync(source, "@test.lua", cancellationTokenSource.Token);
+            Console.WriteLine(r[0]);
+            Assert.Fail("Expected TaskCanceledException was not thrown.");
+        }
+        catch (Exception e)
+        {
+            Assert.That(e, Is.TypeOf<LuaCancelledException>());
+            Console.WriteLine(e.StackTrace);
+            var luaCancelledException = (LuaCancelledException)e;
+            Assert.That(luaCancelledException.InnerException, Is.Null);
+            var traceback = luaCancelledException.LuaTraceback;
+            if (traceback != null)
+            {
+                var luaStackTrace = traceback.ToString();
+                Console.WriteLine(luaStackTrace);
+            }
+        }
+    }
+    
+    [Test]
+    public async Task GoToLoopTest()
+    {
+        var source = """
+                     local ret = 0
+                     ::loop::
+                     ret = ret + 1
+                     goto loop
+                     return ret
+                     """;
+        var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.CancelAfter(100);
+        cancellationTokenSource.Token.Register(() =>
+        {
+            Console.WriteLine("Cancellation requested");
+        });
+        try
+        {
+            var r = await state.DoStringAsync(source, "@test.lua", cancellationTokenSource.Token);
+            Console.WriteLine(r[0]);
+            Assert.Fail("Expected TaskCanceledException was not thrown.");
+        }
+        catch (Exception e)
+        {
+            Assert.That(e, Is.TypeOf<LuaCancelledException>());
+            Console.WriteLine(e.StackTrace);
+            var luaCancelledException = (LuaCancelledException)e;
+            Assert.That(luaCancelledException.InnerException, Is.Null);
+            var traceback = luaCancelledException.LuaTraceback;
+            if (traceback != null)
+            {
+                var luaStackTrace = traceback.ToString();
+                Console.WriteLine(luaStackTrace);
+            }
+        }
+    }
+}


### PR DESCRIPTION
As long as multi-threaded cancellation is performed, infinite loops can be avoided.
```lua
local ret = 0
::loop::
ret = ret + 1
goto loop
return ret
```
```cs
var state = LuaState.Create();
var cancellationTokenSource = new CancellationTokenSource();
cancellationTokenSource.CancelAfter(100);
await state.DoStringAsync(source, "@test.lua", cancellationTokenSource.Token);
```

```
Lua.LuaCancelledException : The operation was cancelled during execution on Lua.
```