### PR TITLE
feat: implement basic support for c# params

### DIFF
--- a/src/Lua.SourceGenerator/MethodMetadata.cs
+++ b/src/Lua.SourceGenerator/MethodMetadata.cs
@@ -19,7 +19,10 @@ internal class MethodMetadata
         IsStatic = symbol.IsStatic;
 
         var returnType = symbol.ReturnType;
-        var fullName = (returnType.ContainingNamespace.IsGlobalNamespace ? "" : (returnType.ContainingNamespace + ".")) + returnType.Name;
+        var isArray = returnType is IArrayTypeSymbol arrayType;
+        var fullName = isArray ?
+            "System.Array"
+            : (returnType.ContainingNamespace.IsGlobalNamespace ? "" : (returnType.ContainingNamespace + ".")) + returnType.Name;
         IsAsync = fullName is "System.Threading.Tasks.Task"
             or "System.Threading.Tasks.ValueTask"
             or "Cysharp.Threading.Tasks.UniTask"

--- a/tests/Lua.Tests/LuaObjectTests.cs
+++ b/tests/Lua.Tests/LuaObjectTests.cs
@@ -18,6 +18,19 @@ public partial class TestUserData
     }
 
     [LuaMember]
+    public static LuaTable ParamsMethod(params LuaValue[] arguments)
+    {
+        var table = new LuaTable(arguments.Length, arguments.Length);
+        for (int i = 0; i < arguments.Length; i++)
+        {
+            // lua starts at 1
+            table[i + 1] = arguments[i];
+        }
+
+        return table;
+    }
+
+    [LuaMember]
     public static async Task MethodAsync()
     {
         await Task.CompletedTask;
@@ -86,6 +99,21 @@ public class LuaObjectTests
         var results = await state.DoStringAsync("return test.MethodVoid()");
 
         Assert.That(results, Has.Length.EqualTo(0));
+    }
+
+    [Test]
+    public async Task Test_ParamsMethod()
+    {
+        var userData = new TestUserData();
+
+        var state = LuaState.Create();
+        state.Environment["test"] = userData;
+        var results = await state.DoStringAsync("return test.ParamsMethod('abc', 'def')");
+
+        Assert.That(results, Has.Length.EqualTo(1));
+        var table = results[0].Read<LuaTable>();
+        Assert.That(table[1].Read<string>(), Is.EqualTo("abc"));
+        Assert.That(table[2].Read<string>(), Is.EqualTo("def"));
     }
 
     [Test]


### PR DESCRIPTION
This PR brings basic functionality for C# method `params` in the source generator. Basically supporting methods like this:

```cs
[LuaMember]
public static LuaTable ParamsMethod(params LuaValue[] arguments)
{
    var table = new LuaTable(arguments.Length, arguments.Length);
    for (int i = 0; i < arguments.Length; i++)
    {
        // lua starts at 1
        table[i + 1] = arguments[i];
    }

    return table;
}
```

I tested this use case and tried to not break anything else while doing it. I cannot confirm that all use cases are covered. I will try other use cases too in the future. Please see this as a proof of work and not a fully fledged feature.

I'm implementing this because my Lua integration needs this feature. I'm testing this PR in my project and will apply further fixes if necessary.