### PR TITLE
Fix: using `async Task<LuaValue>` functions with `LuaMember` (#160)

### DIFF
--- a/src/Lua.SourceGenerator/LuaObjectGenerator.Emit.cs
+++ b/src/Lua.SourceGenerator/LuaObjectGenerator.Emit.cs
@@ -416,7 +416,14 @@ partial class LuaObjectGenerator
 
             if (methodMetadata.HasReturnValue)
             {
-                if (SymbolEqualityComparer.Default.Equals(methodMetadata.Symbol.ReturnType, references.LuaValue))
+                var returnType = methodMetadata.Symbol.ReturnType;
+
+                if (returnType is INamedTypeSymbol named && named.OriginalDefinition.ToString() == "System.Threading.Tasks.Task<TResult>")
+                {
+                    returnType = named.TypeArguments[0];
+                }
+
+                if (SymbolEqualityComparer.Default.Equals(returnType, references.LuaValue))
                 {
                     builder.AppendLine("buffer.Span[0] = result;");
                 }

--- a/tests/Lua.Tests/LuaObjectTests.cs
+++ b/tests/Lua.Tests/LuaObjectTests.cs
@@ -24,6 +24,13 @@ public partial class TestUserData
     }
 
     [LuaMember]
+    public static async Task<LuaValue> MethodLuaValueAsync(bool condition)
+    {
+        await Task.Yield();
+        return condition ? new LuaValue(12) : LuaValue.Nil;
+    }
+
+    [LuaMember]
     public static double StaticMethodWithReturnValue(double a, double b)
     {
         return a + b;
@@ -98,6 +105,22 @@ public class LuaObjectTests
         var results = await state.DoStringAsync("return test.MethodAsync()");
 
         Assert.That(results, Has.Length.EqualTo(0));
+    }
+
+    [Test]
+    public async Task Test_MethodLuaValueAsync()
+    {
+        var userData = new TestUserData();
+
+        var state = LuaState.Create();
+        state.Environment["test"] = userData;
+        var resultsNumber = await state.DoStringAsync("return test.MethodLuaValueAsync(true)");
+        var resultsNill = await state.DoStringAsync("return test.MethodLuaValueAsync(false)");
+
+        Assert.That(resultsNumber, Has.Length.EqualTo(1));
+        Assert.That(resultsNumber[0], Is.EqualTo(new LuaValue(12)));
+        Assert.That(resultsNill, Has.Length.EqualTo(1));
+        Assert.That(resultsNill[0], Is.EqualTo(LuaValue.Nil));
     }
 
     [Test]


### PR DESCRIPTION
Fixing the #160 issue problem, since I need that in my apps.

I tried my best to solve the problem, I never used source generator before.