### PR TITLE
Fix default solution VS Code setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "dotnet.defaultSolution": "Lua.sln",
+    "dotnet.defaultSolution": "Lua.slnx",
     "Lua.diagnostics.globals": [
         "vec3",
         "Vector3"


### PR DESCRIPTION
This is an easy one. The VS Code settings were pointing to a `.sln` file that doesn't exist. This fix points to the correct `.slnx`.