### PR TITLE
VS Code setting to skip final newline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
         "Vector3"
     ],
     "Lua.runtime.version": "Lua 5.2",
-    "dotnet.backgroundAnalysis.analyzerDiagnosticsScope": "fullSolution"
+    "dotnet.backgroundAnalysis.analyzerDiagnosticsScope": "fullSolution",
+    "files.insertFinalNewline": false
 }


### PR DESCRIPTION
VS Code keeps making messy diffs. This should help future PRs.