### PR TITLE
fix: align `%p` behavior with native C Lua

### DIFF
--- a/src/Lua/Standard/Internal/MatchState.cs
+++ b/src/Lua/Standard/Internal/MatchState.cs
@@ -461,7 +461,10 @@ sealed class MatchState(LuaState state, string source, string pattern)
                 break;
             case 'p':
                 // Emulate C ispunct; .NET's char.IsPunctuation does not include symbols like '='.
-                res = !char.IsLetterOrDigit(c) && !char.IsControl(c) && !char.IsWhiteSpace(c);
+                res = (c >= '!' && c <= '/') ||
+                      (c >= ':' && c <= '@') ||
+                      (c >= '[' && c <= '`') ||
+                      (c >= '{' && c <= '~');
                 break;
             case 's':
                 res = char.IsWhiteSpace(c);

--- a/src/Lua/Standard/Internal/MatchState.cs
+++ b/src/Lua/Standard/Internal/MatchState.cs
@@ -461,10 +461,12 @@ sealed class MatchState(LuaState state, string source, string pattern)
                 break;
             case 'p':
                 // Emulate C ispunct; .NET's char.IsPunctuation does not include symbols like '='.
-                res = (c >= '!' && c <= '/') ||
-                      (c >= ':' && c <= '@') ||
-                      (c >= '[' && c <= '`') ||
-                      (c >= '{' && c <= '~');
+                res =
+                    c
+                        is (>= '!' and <= '/')
+                            or (>= ':' and <= '@')
+                            or (>= '[' and <= '`')
+                            or (>= '{' and <= '~');
                 break;
             case 's':
                 res = char.IsWhiteSpace(c);

--- a/src/Lua/Standard/Internal/MatchState.cs
+++ b/src/Lua/Standard/Internal/MatchState.cs
@@ -460,7 +460,8 @@ sealed class MatchState(LuaState state, string source, string pattern)
                 res = char.IsLower(c);
                 break;
             case 'p':
-                res = char.IsPunctuation(c);
+                // Emulate C ispunct; .NET's char.IsPunctuation does not include symbols like '='.
+                res = !char.IsLetterOrDigit(c) && !char.IsControl(c) && !char.IsWhiteSpace(c);
                 break;
             case 's':
                 res = char.IsWhiteSpace(c);

--- a/tests/Lua.Tests/PatternMatchingTests.cs
+++ b/tests/Lua.Tests/PatternMatchingTests.cs
@@ -598,6 +598,39 @@ public class PatternMatchingTests
     }
 
     [Test]
+    public async Task Test_StringGSub_PunctuationClassCapturesSymbolCharacters()
+    {
+        var state = LuaState.Create();
+        state.OpenStringLibrary();
+
+        var result = await state.DoStringAsync(
+            """
+            local punctuation = [=[!"#$%&'()*+,-./
+            :;<=>?@
+            [\]^_`
+            {|}~]=]
+            local matched = ''
+            local count = 0
+            string.gsub(punctuation, '%p', function(c)
+                matched = matched .. c
+                count = count + 1
+            end)
+            return matched, count
+            """
+        );
+
+        Assert.That(result[0].Read<string>(), Is.EqualTo("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"));
+        Assert.That(result[1].Read<double>(), Is.EqualTo(32));
+
+        result = await state.DoStringAsync(
+            "return string.gsub('abc=xyz', '(%w*)(%p)(%w+)', '%3%2%1-%0')"
+        );
+
+        Assert.That(result[0].Read<string>(), Is.EqualTo("xyz=abc-abc=xyz"));
+        Assert.That(result[1].Read<double>(), Is.EqualTo(1));
+    }
+
+    [Test]
     public async Task Test_StringGSub_FunctionReplacements()
     {
         var state = LuaState.Create();

--- a/tests/Lua.Tests/PatternMatchingTests.cs
+++ b/tests/Lua.Tests/PatternMatchingTests.cs
@@ -598,7 +598,7 @@ public class PatternMatchingTests
     }
 
     [Test]
-    public async Task Test_StringGSub_PunctuationClassCapturesSymbolCharacters()
+    public async Task Test_StringGSub_PunctuationClassCapturesAsciiSymbolCharacters()
     {
         var state = LuaState.Create();
         state.OpenStringLibrary();
@@ -621,6 +621,17 @@ public class PatternMatchingTests
 
         Assert.That(result[0].Read<string>(), Is.EqualTo("!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"));
         Assert.That(result[1].Read<double>(), Is.EqualTo(32));
+
+        // Lua %p does not capture non-ASCII punctuation characters
+        result = await state.DoStringAsync(
+            """
+            local text = '’،。、！？'
+            return string.gsub(text, '%p', 'X')
+            """
+        );
+
+        Assert.That(result[0].Read<string>(), Is.EqualTo("’،。、！？"));
+        Assert.That(result[1].Read<double>(), Is.EqualTo(0));
 
         result = await state.DoStringAsync(
             "return string.gsub('abc=xyz', '(%w*)(%p)(%w+)', '%3%2%1-%0')"


### PR DESCRIPTION
In C Lua, when checking if a character matches `%p`, it uses C's `ispunct` function. Unlike C#'s `char.IsPunctuation`, `ispunct`also matches characters like `=`. For example, in C Lua, the following expression evaluates to true:

```lua
string.gsub("abc=xyz", "(%w*)(%p)(%w+)", "%3%2%1-%0") == "xyz=abc-abc=xyz"
```

This PR aligns the behavior of `%p` with that of C Lua as described above.