### PR TITLE
LuaMember AllowNil support

### DIFF
--- a/src/Lua.Annotations/Attributes.cs
+++ b/src/Lua.Annotations/Attributes.cs
@@ -24,6 +24,8 @@ public sealed class LuaMemberAttribute : Attribute
     }
 
     public string? Name { get; }
+
+    public bool AllowNil { get; set; }
 }
 
 [AttributeUsage(AttributeTargets.Method)]

--- a/src/Lua.SourceGenerator/DiagnosticDescriptors.cs
+++ b/src/Lua.SourceGenerator/DiagnosticDescriptors.cs
@@ -68,4 +68,13 @@ public static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true
     );
+
+    public static readonly DiagnosticDescriptor InvalidAllowNilMemberType = new(
+        id: "LUACS008",
+        title: "AllowNil can only be used on LuaObject reference type members.",
+        messageFormat: "AllowNil can only be used on LuaObject reference type members.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true
+    );
 }

--- a/src/Lua.SourceGenerator/LuaObjectGenerator.Emit.cs
+++ b/src/Lua.SourceGenerator/LuaObjectGenerator.Emit.cs
@@ -32,6 +32,21 @@ partial class LuaObjectGenerator
         return $"{GetLuaValuePrefix(typeSymbol, references, compilation)}{expression})";
     }
 
+    static bool CanAllowNil(ITypeSymbol typeSymbol, SymbolReferences references)
+    {
+        return typeSymbol.IsReferenceType && typeSymbol.ContainsAttribute(references.LuaObjectAttribute);
+    }
+
+    static string GetContextArgumentExpression(
+        int argumentIndex,
+        ITypeSymbol typeSymbol,
+        bool allowNil
+    )
+    {
+        var methodName = allowNil ? "GetArgumentOrDefault" : "GetArgument";
+        return $"context.{methodName}<{typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>({argumentIndex})";
+    }
+
     static bool TryEmit(
         TypeMetadata typeMetadata,
         CodeBuilder builder,
@@ -229,6 +244,19 @@ partial class LuaObjectGenerator
 
         foreach (var property in typeMetadata.Properties)
         {
+            if (property.AllowNil && !CanAllowNil(property.Type, references))
+            {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        DiagnosticDescriptors.InvalidAllowNilMemberType,
+                        property.Symbol.Locations.FirstOrDefault()
+                    )
+                );
+
+                isValid = false;
+                continue;
+            }
+
             if (SymbolEqualityComparer.Default.Equals(property.Type, references.LuaValue))
             {
                 continue;
@@ -667,7 +695,7 @@ partial class LuaObjectGenerator
                             else
                             {
                                 builder.AppendLine(
-                                    $"{typeMetadata.FullTypeName}.{propertyMetadata.Symbol.Name} = context.GetArgument<{propertyMetadata.TypeFullName}>(2);"
+                                    $"{typeMetadata.FullTypeName}.{propertyMetadata.Symbol.Name} = {GetContextArgumentExpression(2, propertyMetadata.Type, propertyMetadata.AllowNil)};"
                                 );
                             }
 
@@ -691,7 +719,7 @@ partial class LuaObjectGenerator
                             else
                             {
                                 builder.AppendLine(
-                                    $"userData.{propertyMetadata.Symbol.Name} = context.GetArgument<{propertyMetadata.TypeFullName}>(2);"
+                                    $"userData.{propertyMetadata.Symbol.Name} = {GetContextArgumentExpression(2, propertyMetadata.Type, propertyMetadata.AllowNil)};"
                                 );
                             }
 

--- a/src/Lua.SourceGenerator/LuaObjectGenerator.Emit.cs
+++ b/src/Lua.SourceGenerator/LuaObjectGenerator.Emit.cs
@@ -43,8 +43,11 @@ partial class LuaObjectGenerator
         bool allowNil
     )
     {
-        var methodName = allowNil ? "GetArgumentOrDefault" : "GetArgument";
-        return $"context.{methodName}<{typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}>({argumentIndex})";
+        var typeName = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var argumentExpression = $"context.GetArgument<{typeName}>({argumentIndex})";
+        return allowNil
+            ? $"context.HasArgument({argumentIndex}) ? {argumentExpression} : default({typeName})"
+            : argumentExpression;
     }
 
     static bool TryEmit(

--- a/src/Lua.SourceGenerator/PropertyMetadata.cs
+++ b/src/Lua.SourceGenerator/PropertyMetadata.cs
@@ -10,6 +10,7 @@ public class PropertyMetadata
     public bool IsStatic { get; }
     public bool IsReadOnly { get; }
     public bool IsWriteOnly { get; }
+    public bool AllowNil { get; }
     public string LuaMemberName { get; }
 
     public PropertyMetadata(ISymbol symbol, SymbolReferences references)
@@ -49,6 +50,15 @@ public class PropertyMetadata
                 if (value is string str)
                 {
                     LuaMemberName = str;
+                }
+            }
+
+            foreach (var namedArgument in memberAttribute.NamedArguments)
+            {
+                if (namedArgument.Key == "AllowNil" &&
+                    namedArgument.Value.Value is bool allowNil)
+                {
+                    AllowNil = allowNil;
                 }
             }
         }

--- a/tests/Lua.Tests/LuaObjectTests.cs
+++ b/tests/Lua.Tests/LuaObjectTests.cs
@@ -138,6 +138,23 @@ public partial class TestUserData
 }
 
 [LuaObject]
+public partial class AllowNilReferencedObject
+{
+    [LuaMember("label")]
+    public string Label { get; set; } = "";
+}
+
+[LuaObject]
+public partial class AllowNilMemberContainer
+{
+    [LuaMember("optionalObject", AllowNil = true)]
+    public AllowNilReferencedObject OptionalObject { get; set; } = null!;
+
+    [LuaMember("requiredObject")]
+    public AllowNilReferencedObject RequiredObject { get; set; } = null!;
+}
+
+[LuaObject]
 public partial class IntArrayUserData
 {
     public int[] Array { get; } = new int[10];
@@ -194,7 +211,6 @@ public partial class StringKeyUserData
     }
 }
 
-[LuaObject]
 public abstract partial class ParentClass
 {
     [LuaMember("value")]
@@ -237,6 +253,47 @@ public class LuaObjectTests
 
         Assert.That(results, Has.Length.EqualTo(1));
         Assert.That(results[0], Is.EqualTo(new LuaValue("foo")));
+    }
+
+    [Test]
+    public async Task Test_LuaMemberAllowNilLuaObjectPropertyCanBeSetToNil()
+    {
+        var referencedObject = new AllowNilReferencedObject { Label = "reference" };
+        var userData = new AllowNilMemberContainer { OptionalObject = referencedObject };
+
+        var state = LuaState.Create();
+        state.Environment["referencedObject"] = referencedObject;
+        state.Environment["target"] = userData;
+        var results = await state.DoStringAsync("""
+                                                local oldObject = target.optionalObject
+                                                target.optionalObject = nil
+                                                local nilObject = target.optionalObject
+                                                target.optionalObject = referencedObject
+                                                return oldObject.label, nilObject, target.optionalObject.label
+                                                """);
+
+        Assert.That(results, Has.Length.EqualTo(3));
+        Assert.That(results[0], Is.EqualTo(new LuaValue("reference")));
+        Assert.That(results[1], Is.EqualTo(LuaValue.Nil));
+        Assert.That(results[2], Is.EqualTo(new LuaValue("reference")));
+        Assert.That(userData.OptionalObject, Is.SameAs(referencedObject));
+    }
+
+    [Test]
+    public async Task Test_LuaObjectPropertyRejectsNilWithoutAllowNil()
+    {
+        var referencedObject = new AllowNilReferencedObject { Label = "reference" };
+        var userData = new AllowNilMemberContainer { RequiredObject = referencedObject };
+
+        var state = LuaState.Create();
+        state.Environment["target"] = userData;
+        var exception = Assert.ThrowsAsync<LuaRuntimeException>(async () =>
+        {
+            await state.DoStringAsync("target.requiredObject = nil");
+        });
+
+        Assert.That(exception!.Message, Does.Contain("bad argument #3"));
+        Assert.That(userData.RequiredObject, Is.SameAs(referencedObject));
     }
 
     [Test]


### PR DESCRIPTION
Allows `LuaMember`s that hold `LuaObject`s to accept `nil` assignment from Lua via `[LuaMember("my_prop", AllowNil = true)]`. This aligns with the C# concept of said `LuaObject`s being reference types, and thus, accepting `null`

```csharp
[LuaObject]
public partial class AllowNilReferencedObject
{
    [LuaMember("label")]
    public string Label { get; set; } = "";
}

[LuaObject]
public partial class AllowNilMemberContainer
{
    [LuaMember("optionalObject", AllowNil = true)]
    public AllowNilReferencedObject OptionalObject { get; set; } = null!;

    [LuaMember("requiredObject")]
    public AllowNilReferencedObject RequiredObject { get; set; } = null!;
}

state.Environment["target"] = new AllowNilMemberContainer();
state.Environment["reference"] = new AllowNilReferencedObject();
```

```lua
target.optionalObject = reference -- Works
target.optionalObject = nil -- Works
target.requiredObject = reference -- Works
target.requiredObject = nil -- Fails
```

In C#, `state.Environment["target"]. OptionalObject` is `null`.