### PR TITLE
Ignore JetBrains temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 .claude/settings.local.json
 artifacts/
+
+/.idea/
+*.sln.DotSettings.user


### PR DESCRIPTION
small addition to .gitignore to skip user-dependent files created by JetBrains IDE.