### PR TITLE
Fixes issues where lua uses the C# default locale instead of the invariant locale (C)

### DIFF
--- a/src/Lua/Standard/Internal/DateTimeHelper.cs
+++ b/src/Lua/Standard/Internal/DateTimeHelper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -165,14 +166,14 @@ static class DateTimeHelper
             var pattern = STANDARD_PATTERNS(c);
             if (pattern != null)
             {
-                builder.Append(d.ToString(pattern));
+                builder.Append(d.ToString(pattern, CultureInfo.InvariantCulture));
             }
             else
                 switch (c)
                 {
                     case 'e':
                     {
-                        var s = d.ToString("%d");
+                        var s = d.ToString("%d", CultureInfo.InvariantCulture);
                         builder.Append(s.Length < 2 ? $" {s}" : s);
                         break;
                     }
@@ -184,10 +185,10 @@ static class DateTimeHelper
                         break;
                     case 'C':
                         // TODO: reduce allocation
-                        builder.Append((d.Year / 100).ToString());
+                        builder.Append((d.Year / 100).ToString(CultureInfo.InvariantCulture));
                         break;
                     case 'j':
-                        builder.Append(d.DayOfYear.ToString("000"));
+                        builder.Append(d.DayOfYear.ToString("000", CultureInfo.InvariantCulture));
                         break;
                     case 'u':
                     {
@@ -197,13 +198,13 @@ static class DateTimeHelper
                             weekDay = 7;
                         }
 
-                        builder.Append(weekDay.ToString());
+                        builder.Append(weekDay.ToString(CultureInfo.InvariantCulture));
                         break;
                     }
                     case 'w':
                     {
                         var weekDay = (int)d.DayOfWeek;
-                        builder.Append(weekDay.ToString());
+                        builder.Append(weekDay.ToString(CultureInfo.InvariantCulture));
                         break;
                     }
                     case 'U':

--- a/src/Lua/Standard/Internal/IOHelper.cs
+++ b/src/Lua/Standard/Internal/IOHelper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Lua.Internal;
 using Lua.IO;
 
@@ -70,7 +71,7 @@ static class IOHelper
                 {
                     using PooledArray<char> fileBuffer = new(64);
                     var span = fileBuffer.AsSpan();
-                    d.TryFormat(span, out var charsWritten);
+                    d.TryFormat(span, out var charsWritten, provider: CultureInfo.InvariantCulture);
                     await file.WriteAsync(
                         fileBuffer.UnderlyingArray.AsMemory(0, charsWritten),
                         cancellationToken

--- a/tests/Lua.Tests/DateTimeTests.cs
+++ b/tests/Lua.Tests/DateTimeTests.cs
@@ -1,6 +1,7 @@
 ﻿using Lua.Platforms;
 using Lua.Standard;
 using Microsoft.Extensions.Time.Testing;
+using System.Globalization;
 
 namespace Lua.Tests;
 
@@ -55,6 +56,28 @@ public class DateTimeTests
 
         Assert.That(result, Has.Length.EqualTo(1));
         Assert.That(result[0], Is.EqualTo(new LuaValue("2000")));
+    }
+
+    [Test]
+    public async Task OsDate_UsesCLocaleForNames()
+    {
+        var culture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+        try
+        {
+            var state = LuaState.Create();
+            state.OpenOperatingSystemLibrary();
+
+            // 946771200 is the unix time for 2000-01-02 00:00:00 UTC
+            var result = await state.DoStringAsync("""return os.date("!%A %B", 946771200)""");
+
+            Assert.That(result, Has.Length.EqualTo(1));
+            Assert.That(result[0], Is.EqualTo(new LuaValue("Sunday January")));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = culture;
+        }
     }
 
     [Test]

--- a/tests/Lua.Tests/DateTimeTests.cs
+++ b/tests/Lua.Tests/DateTimeTests.cs
@@ -59,12 +59,22 @@ public class DateTimeTests
     }
 
     [Test]
+    [NonParallelizable]
     public async Task OsDate_UsesCLocaleForNames()
     {
-        var culture = CultureInfo.CurrentCulture;
-        CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+        var originalCulture = CultureInfo.CurrentCulture;
         try
         {
+            try
+            {
+                CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            }
+            catch (CultureNotFoundException)
+            {
+                Assert.Ignore("Required culture 'de-DE' is not available in this runtime.");
+                return;
+            }
+
             var state = LuaState.Create();
             state.OpenOperatingSystemLibrary();
 
@@ -76,7 +86,7 @@ public class DateTimeTests
         }
         finally
         {
-            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentCulture = originalCulture;
         }
     }
 


### PR DESCRIPTION
os.setlocale only supports "C" in Lua-CSharp and that is the assumed default. 

Most places already use invariant locale, but io.write and os.date still used the locale set by .NET, leading to inconsistent results on machines with a non-US locale (e.g. my de/DE)