### PR TITLE
Add proactive stack overflow detection via MaxCallDepth + tests

### DIFF
--- a/src/Lua/Exceptions.cs
+++ b/src/Lua/Exceptions.cs
@@ -99,7 +99,7 @@ public class LuaCompileException(
 
 public class LuaUndumpException(string message) : Exception(message);
 
-class LuaStackOverflowException() : Exception("stack overflow")
+public class LuaStackOverflowException() : Exception("stack overflow")
 {
     public override string ToString()
     {

--- a/src/Lua/LuaState.cs
+++ b/src/Lua/LuaState.cs
@@ -197,6 +197,8 @@ public class LuaState : IDisposable
     public LuaTable PreloadModules => GlobalState.PreloadModules;
     public LuaState MainThread => GlobalState.MainThread;
 
+    public int MaxCallDepth { get; set; } = 100_000;
+
     public ILuaModuleLoader? ModuleLoader
     {
         get => GlobalState.ModuleLoader;
@@ -285,6 +287,11 @@ public class LuaState : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void PushCallStackFrame(in CallStackFrame frame)
     {
+        if (CallStackFrameCount >= MaxCallDepth)
+        {
+            throw new LuaStackOverflowException();
+        }
+
         CurrentException?.BuildOrGet();
         CurrentException = null;
         ref var callStack = ref CoreData!.CallStack;

--- a/src/Lua/Runtime/LuaVirtualMachine.cs
+++ b/src/Lua/Runtime/LuaVirtualMachine.cs
@@ -1419,6 +1419,11 @@ public static partial class LuaVirtualMachine
 
         var newFrame = func.CreateNewFrame(context, newBase, RA, variableArgumentCount);
 
+        if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+        {
+            throw new LuaStackOverflowException();
+        }
+
         state.PushCallStackFrame(newFrame);
         if (state.CallOrReturnHookMask.Value != 0 && !context.State.IsInHook)
         {
@@ -1619,6 +1624,12 @@ public static partial class LuaVirtualMachine
         );
         newBase = context.FrameBase + variableArgumentCount;
         stack.PopUntil(newBase + argumentCount);
+
+        if (!RuntimeHelpers.TryEnsureSufficientExecutionStack())
+        {
+            throw new LuaStackOverflowException();
+        }
+
         var lastFrame = state.GetCurrentFrame();
         state.LastPc = context.Pc;
         state.LastCallerFunction = lastFrame.Function;

--- a/src/Lua/Standard/BasicLibrary.cs
+++ b/src/Lua/Standard/BasicLibrary.cs
@@ -367,6 +367,8 @@ public sealed class BasicLibrary
                     throw;
                 case OperationCanceledException:
                     throw new LuaCanceledException(context.State, cancellationToken, ex);
+                case LuaStackOverflowException:
+                    return context.Return(false, ex.Message);
                 case LuaRuntimeException luaEx:
                 {
                     if (

--- a/tests/Lua.Tests/StackOverflowTests.cs
+++ b/tests/Lua.Tests/StackOverflowTests.cs
@@ -1,0 +1,87 @@
+using Lua.Standard;
+
+namespace Lua.Tests;
+
+public class StackOverflowTests
+{
+    [Test]
+    public void ExceedingMaxCallDepth_ThrowsLuaRuntimeException()
+    {
+        var state = LuaState.Create();
+        state.MaxCallDepth = 5;
+
+        var ex = Assert.ThrowsAsync<LuaRuntimeException>(async () =>
+            await state.DoStringAsync(
+                """
+                local function f()
+                    f()
+                end
+                f()
+                """
+            ).AsTask()
+        );
+
+        Assert.That(ex!.InnerException, Is.TypeOf<LuaStackOverflowException>());
+    }
+
+    [Test]
+    public async Task ExceedingMaxCallDepth_WithPCall_ReturnsErrorMessage()
+    {
+        var state = LuaState.Create();
+        state.OpenStandardLibraries();
+        state.MaxCallDepth = 5;
+
+        var result = await state.DoStringAsync(
+            """
+            local function f()
+                f()
+            end
+            local ok, msg = pcall(f)
+            return ok, msg
+            """
+        );
+
+        Assert.That(result, Has.Length.EqualTo(2));
+        Assert.That(result[0], Is.EqualTo(new LuaValue(false)));
+        Assert.That(result[1].Read<string>(), Does.Contain("stack overflow"));
+    }
+
+    [Test]
+    public async Task UnderMaxCallLimit_Succeeds()
+    {
+        var state = LuaState.Create();
+        state.MaxCallDepth = 100;
+
+        var result = await state.DoStringAsync(
+            """
+            local function f(n)
+                if n <= 0 then return 'done' end
+                return f(n - 1)
+            end
+            return f(10)
+            """
+        );
+
+        Assert.That(result, Has.Length.EqualTo(1));
+        Assert.That(result[0], Is.EqualTo(new LuaValue("done")));
+    }
+
+    [Test]
+    public async Task DefaultMaxCallDepth_AllowsDeepRecursion()
+    {
+        var state = LuaState.Create();
+
+        var result = await state.DoStringAsync(
+            """
+            local function f(n)
+                if n <= 0 then return n end
+                return f(n - 1)
+            end
+            return f(1000)
+            """
+        );
+
+        Assert.That(result, Has.Length.EqualTo(1));
+        Assert.That(result[0], Is.EqualTo(new LuaValue(0)));
+    }
+}


### PR DESCRIPTION
## Description
Adds proactive stack overflow detection to prevent process terminating native `StackOverflowException` and enable sandboxing use.

## Changes
- Add `MaxCallDepth` property to LuaState.
- Add native stack check in `Call` and `TailCall` before pushing frames
- Move logical depth check into `PushCallStackFrames` to cover all the call sites.
- Make LuaStackOverflowException public so users can catch it by type.

## Tests:
Added the following:
- `ExceedingMaxCallDepth_ThrowsLuaRuntimeException`
- `ExceedingMaxCallDepth_WithPCall_ReturnsErrorMessage`
- `UnderMaxCallLimit_Succeeds`
- `DefaultMaxCallDepth_AllowsDeepRecursion`

All tests passed. Ready for review.