### PR TITLE
Inline ThrowInvalidOperationWithName in LuaVirtualMachine.SetTableValueSlowPath

### DIFF
--- a/src/Lua/Runtime/LuaVirtualMachine.cs
+++ b/src/Lua/Runtime/LuaVirtualMachine.cs
@@ -2165,7 +2165,24 @@ public static partial class LuaVirtualMachine
             {
                 if (i == 0)
                 {
-                    ThrowInvalidOperationWithName();
+                    var op = context.Instruction.OpCode;
+                    if (op != OpCode.SetTabUp)
+                    {
+                        LuaRuntimeException.AttemptInvalidOperationOnLuaStack(
+                            GetstateWithCurrentPc(context),
+                            "index",
+                            context.Pc,
+                            context.Instruction.A
+                        );
+                    }
+                    else
+                    {
+                        LuaRuntimeException.AttemptInvalidOperationOnUpValues(
+                            GetstateWithCurrentPc(context),
+                            "index",
+                            context.Instruction.A
+                        );
+                    }
                 }
                 else
                 {
@@ -2188,29 +2205,6 @@ public static partial class LuaVirtualMachine
         }
 
         throw new LuaRuntimeException(GetstateWithCurrentPc(context), "loop in settable");
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        void ThrowInvalidOperationWithName()
-        {
-            var op = context.Instruction.OpCode;
-            if (op != OpCode.SetTabUp)
-            {
-                LuaRuntimeException.AttemptInvalidOperationOnLuaStack(
-                    GetstateWithCurrentPc(context),
-                    "index",
-                    context.Pc,
-                    context.Instruction.A
-                );
-            }
-            else
-            {
-                LuaRuntimeException.AttemptInvalidOperationOnUpValues(
-                    GetstateWithCurrentPc(context),
-                    "index",
-                    context.Instruction.A
-                );
-            }
-        }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
`LuaVirtualMachine.SetTableValueSlowPath` allocates 24 bytes regardless if `ThrowInvalidOperationWithName` was called or not.

This PR inlines the local method to prevent these allocations.

I heavily rely on this in my game loop, so these benign allocations add up fast.