### PR TITLE
Fix stack truncation on metamethod return corrupting numeric for loops

### DIFF
--- a/src/Lua/Runtime/LuaVirtualMachine.cs
+++ b/src/Lua/Runtime/LuaVirtualMachine.cs
@@ -170,7 +170,12 @@ public static partial class LuaVirtualMachine
                 // Other opcodes has one result
                 default:
                     Stack.Get(target) = result.Length == 0 ? LuaValue.Nil : result[0];
-                    State.PopCallStackFrameWithStackPop(target + 1);
+                    // Restore the caller's stack top rather than truncating to the
+                    // result register: the result register may live BELOW other live
+                    // registers (e.g. a numeric for-loop's hidden index/limit/step
+                    // slots, or locals declared before the current expression). The
+                    // metamethod frame's ReturnBase is the caller's top at call time.
+                    State.PopCallStackFrameWithStackPop(Math.Max(target + 1, CurrentReturnFrameBase));
                     return true;
             }
 

--- a/src/Lua/Runtime/LuaVirtualMachine.cs
+++ b/src/Lua/Runtime/LuaVirtualMachine.cs
@@ -170,11 +170,6 @@ public static partial class LuaVirtualMachine
                 // Other opcodes has one result
                 default:
                     Stack.Get(target) = result.Length == 0 ? LuaValue.Nil : result[0];
-                    // Restore the caller's stack top rather than truncating to the
-                    // result register: the result register may live BELOW other live
-                    // registers (e.g. a numeric for-loop's hidden index/limit/step
-                    // slots, or locals declared before the current expression). The
-                    // metamethod frame's ReturnBase is the caller's top at call time.
                     State.PopCallStackFrameWithStackPop(Math.Max(target + 1, CurrentReturnFrameBase));
                     return true;
             }

--- a/tests/Lua.Tests/LoopTests.cs
+++ b/tests/Lua.Tests/LoopTests.cs
@@ -52,12 +52,6 @@ return n";
         Assert.That(result[0], Is.EqualTo(new LuaValue(100)));
     }
 
-    // Regression: returning from a metamethod truncated the stack to the result
-    // register. When that register sat below a numeric for-loop's hidden control
-    // slots (index/limit/step) — which happens when the assignment target is a
-    // local declared before the loop — the control slots were clobbered, the step
-    // decayed to 0, and the loop spun forever. A CancellationToken guards the run so
-    // a re-regression fails fast instead of hanging the whole test suite.
     [Test]
     public async Task Test_NumericFor_MetamethodResultDoesNotCorruptLoopState()
     {
@@ -80,8 +74,6 @@ return acc.v";
         Assert.That(result[0], Is.EqualTo(new LuaValue(15)));
     }
 
-    // Same regression, exercised through an __index metamethod (single-result return
-    // path) with the target local living below the loop's control slots.
     [Test]
     public async Task Test_NumericFor_IndexMetamethodResultDoesNotCorruptLoopState()
     {

--- a/tests/Lua.Tests/LoopTests.cs
+++ b/tests/Lua.Tests/LoopTests.cs
@@ -1,3 +1,5 @@
+using Lua.Standard;
+
 namespace Lua.Tests;
 
 public class LoopTests
@@ -48,5 +50,56 @@ return n";
 
         Assert.That(result, Has.Length.EqualTo(1));
         Assert.That(result[0], Is.EqualTo(new LuaValue(100)));
+    }
+
+    // Regression: returning from a metamethod truncated the stack to the result
+    // register. When that register sat below a numeric for-loop's hidden control
+    // slots (index/limit/step) — which happens when the assignment target is a
+    // local declared before the loop — the control slots were clobbered, the step
+    // decayed to 0, and the loop spun forever. A CancellationToken guards the run so
+    // a re-regression fails fast instead of hanging the whole test suite.
+    [Test]
+    public async Task Test_NumericFor_MetamethodResultDoesNotCorruptLoopState()
+    {
+        var source =
+            @"
+local mt = {}
+mt.__add = function(a, b) return setmetatable({ v = a.v + b.v }, mt) end
+local acc = setmetatable({ v = 0 }, mt)
+for i = 1, 5 do
+    acc = acc + setmetatable({ v = i }, mt)
+end
+return acc.v";
+
+        var state = LuaState.Create();
+        state.OpenStandardLibraries();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var result = await state.DoStringAsync(source, "@test.lua", cts.Token);
+
+        Assert.That(result, Has.Length.EqualTo(1));
+        Assert.That(result[0], Is.EqualTo(new LuaValue(15)));
+    }
+
+    // Same regression, exercised through an __index metamethod (single-result return
+    // path) with the target local living below the loop's control slots.
+    [Test]
+    public async Task Test_NumericFor_IndexMetamethodResultDoesNotCorruptLoopState()
+    {
+        var source =
+            @"
+local proxy = setmetatable({}, { __index = function(_, k) return k end })
+local sum = 0
+for i = 1, 5 do
+    sum = sum + proxy[i]
+end
+return sum";
+
+        var state = LuaState.Create();
+        state.OpenStandardLibraries();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var result = await state.DoStringAsync(source, "@test.lua", cts.Token);
+
+        Assert.That(result, Has.Length.EqualTo(1));
+        Assert.That(result[0], Is.EqualTo(new LuaValue(15)));
     }
 }


### PR DESCRIPTION
My first contribution to this project. We're using this interpreter in our upcoming Unity game, so I think it appropriate to contribute where we can. We made our own Vector class in Lua with operator overrides like `__add` and whatnot. When trying to do these operations in a for loop, it crashes everything. I've explained the issue and fix below as best I can:

## Summary
A metamethod that returns a single value could truncate the caller's stack
below still-live registers, causing numeric `for` loops to run forever.

## Root cause
When an opcode's metamethod resolves to a single result, the VM writes the
result into the target register and then pops the metamethod's call frame. The
"one result" path (`default:` case in `LuaVirtualMachine.Call`) popped the stack
down to `target + 1`:

```csharp
// src/Lua/Runtime/LuaVirtualMachine.cs (before)
default:
    Stack.Get(target) = result.Length == 0 ? LuaValue.Nil : result[0];
    State.PopCallStackFrameWithStackPop(target + 1);
    return true;
```
That assumes nothing above `target` is live. But
```
target = callInstruction.A + FrameBase
```
is the _assignment destination_, which can be a low register when the result is stored into a local declared before the current expression. A numeric `for` loop is the clearest trigger: its hidden control slots (index/limit/step) are allocated in registers above those locals, and `ForLoop` re-reads them from `iA`, `iA+1`, `iA+2` on every iteration:
```
// src/Lua/Runtime/LuaVirtualMachine.cs:897-900
ref var indexRef = ref stack.Get(iA + frameBase);
var limit = Unsafe.Add(ref indexRef, 1).UnsafeReadDouble();
var step  = Unsafe.Add(ref indexRef, 2).UnsafeReadDouble();
var index = indexRef.UnsafeReadDouble() + step;
```
So for a body like:
```
local acc = ...            -- low register
for i = 1, n do
    acc = acc + something  -- __add result lands in acc's low register
end
```
the `__add` return truncated the stack past `acc`, discarding the loop's index/limit/step slots. `step` then reads back as `0`, the termination check `step >= 0 ? index <= limit : ...` never advances, and the loop spins forever

Notably, the sibling `Self` case already pops to `target + 2` rather than `target + 1` (LuaVirtualMachine.cs line 164), acknowledging that registers above the result can be live — the `default:` path simply missed the general case.

## Fix
Restore the caller's stack top instead of truncating to the result register. The metamethod frame's `ReturnBase`, captured as `CurrentReturnFrameBase` when the frame is entered (LuaVirtualMachine.cs lines 39 and 115), is the caller's top at call time, so it preserves any registers that were live above the result:
```
// src/Lua/Runtime/LuaVirtualMachine.cs (after)
default:
    Stack.Get(target) = result.Length == 0 ? LuaValue.Nil : result[0];
    State.PopCallStackFrameWithStackPop(Math.Max(target + 1, CurrentReturnFrameBase));
    return true;
```
`Math.Max` keeps the original behavior when the result register is already at or above the caller's top, and only extends the retained region when live slots sit above it.

The regression tests I added mirror the situation we were having when we noticed the problem in the first place.

Please review this and let me know if this appropriate to do, or if there's a better way.