### PR TITLE
fix: LightAsyncValueTaskMethodBuilder<T> allocation

### DIFF
--- a/src/Lua/Internal/CompilerServices/LightAsyncTaskMethodBuilder.cs
+++ b/src/Lua/Internal/CompilerServices/LightAsyncTaskMethodBuilder.cs
@@ -179,7 +179,7 @@ struct LightAsyncValueTaskMethodBuilder<T>
             }
 
             {
-                return new(System.Threading.Tasks.Task.FromResult(result));
+                return new(result);
             }
         }
     }


### PR DESCRIPTION
`LightAsyncValueTaskMethodBuilder<T>.Task` allocates a `Task<T>` on the synchronous-completion path:

```csharp
return new(System.Threading.Tasks.Task.FromResult(result));
```

`Task.FromResult` allocates unconditionally, so every synchronously-completing async method built with this builder heap-allocates — which is the cost `ValueTask<T>` exists to avoid. `ValueTask<T>` has a constructor that carries the result directly, with no backing `Task`:

```csharp
return new(result);
```

The non-generic `LightAsyncValueTaskMethodBuilder` is already allocation-free here, since `Task.CompletedTask` is a cached singleton — so this only affects the generic overload.

Since 235e265 applied this builder across the internals, the allocation shows up on any hot path where internal async methods complete synchronously, which is the common case.

### Impact

Found while profiling a Unity game that drives Lua scripts per frame. Every `__index` / `__newindex` metamethod dispatch completes synchronously and hits this path — 1.3 KB per 17 Lua invocations, ~2.7 KB per frame per scripted entity, scaling with entity count. Removing it took that to zero, with no other change.

### Verification

- `dotnet build Lua.slnx -c Release` — 0 errors
- `dotnet test tests/Lua.Tests/Lua.Tests.csproj -c Release --filter "TestCategory!=ExpectedFailure"` — 273 passed, 0 failed
- Verified in the emitted IL that `Task::FromResult` is gone and the allocation-free `ValueTask<T>(TResult)` constructor is used
- Public API surface unchanged (115 public types before and after)
